### PR TITLE
Refactor mmap server to Flask

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ http://www.youtube.com/watch?v=QNql3n4C8iA
 Requirements
 ------------
 
-Mavelous depends on [CherryPy](http://www.cherrypy.org/) and
-[Flask](http://flask.pocoo.org/), which can be easily installed with
-`easy_install` or `pip`:
+Mavelous depends on [Flask](https://palletsprojects.com/p/flask/).
+For production deployments we recommend the [Gunicorn](https://gunicorn.org/)
+WSGI server.  Install the required packages with `pip`:
 
-    $ pip install flask cherrypy
+    $ pip install flask gunicorn
 
 
 Architecture
@@ -123,6 +123,14 @@ How to run it
 
 A web browser will open showing you the Mavelous interface, or you can point a browser to http://localhost:9999.
 
+During development the mmap module launches Flask's built-in server in
+the background. For production you can serve the same application with
+Gunicorn:
+
+```bash
+$ gunicorn modules.lib.mmap_server:app
+```
+
 You'll be able to use the Mavelous interface to control Guided mode once in
 flight. Find out more about guided mode on [ArduCopter](http://code.google.com/p/arducopter/wiki/AC2_GuidedMode).
 
@@ -164,6 +172,8 @@ flight. Find out more about guided mode on [ArduCopter](http://code.google.com/p
     ```
 
 A web browser will open showing you the Mavelous interface, or you can point a browser to http://localhost:9999
+During development the mmap module launches Flask's built-in server in
+the background. To run in production use Gunicorn as shown above.
 
 
 

--- a/modules/lib/mmap_server.py
+++ b/modules/lib/mmap_server.py
@@ -3,16 +3,17 @@ import os
 import os.path
 import threading
 import types
+import time
 
-from cherrypy import wsgiserver
 import flask
-from werkzeug import wsgi
+from werkzeug.middleware.shared_data import SharedDataMiddleware
+from werkzeug.serving import make_server
 
 app = flask.Flask(__name__)
 
 DOC_DIR = os.path.join(os.path.dirname(__file__), 'mmap_app')
 
-app.wsgi_app = wsgi.SharedDataMiddleware(
+app.wsgi_app = SharedDataMiddleware(
   app.wsgi_app,
   {'/': DOC_DIR})
 
@@ -42,7 +43,10 @@ def command_handler():
   # FIXME: I couldn't figure out how to get jquery to send a
   # Content-Type: application/json, which would have let us use
   # request.json.  And for some reason the data is in the key name.
-  body_obj = json.loads(flask.request.form.keys()[0])
+  # In older jQuery versions the payload ended up as the key name of the
+  # form dictionary. ``keys()`` now returns a view so grab the first item
+  # explicitly for compatibility with Flask 2.x.
+  body_obj = json.loads(next(iter(flask.request.form.keys())))
   app.module_state.command(body_obj)
   return 'OK'
 
@@ -68,13 +72,37 @@ def response_dict_for_message(msg, time, index):
   return resp
 
 
+class _ServerWrapper(threading.Thread):
+  """Runs the Flask application in a background thread."""
+
+  def __init__(self, host, port):
+    threading.Thread.__init__(self)
+    self.daemon = True
+    self.server = make_server(host, port, app)
+
+  def run(self):
+    self.server.serve_forever()
+
+  def terminate(self):
+    self.server.shutdown()
+
+
 def start_server(address, port, module_state):
-  dispatcher = wsgiserver.WSGIPathInfoDispatcher({'/': app})
-  server = wsgiserver.CherryPyWSGIServer(
-    (address, port),
-    dispatcher)
-  server_thread = threading.Thread(target=server.start)
-  server_thread.daemon = True
-  server_thread.start()
+  """Start the web server in a background thread."""
+  srv = _ServerWrapper(address, port)
   app.module_state = module_state
-  return server
+  srv.start()
+  return srv
+
+
+if __name__ == '__main__':
+  # Simple entry point for running the server directly in development.
+  class _State(object):
+    messages = None
+
+  start_server('127.0.0.1', 9999, module_state=_State())
+  try:
+    while True:
+      time.sleep(1)
+  except KeyboardInterrupt:
+    pass


### PR DESCRIPTION
## Summary
- switch server to run on Flask/werkzeug
- drop deprecated cherrypy usage
- document Flask/gunicorn usage for development and production

## Testing
- `pip install flask gunicorn`
- `python modules/lib/mmap_server.py`

------
https://chatgpt.com/codex/tasks/task_e_6868b78689848324a7fc4dc8a1478559