### PR TITLE
Port scripts to Python 3

### DIFF
--- a/modules/CUAV/camera.py
+++ b/modules/CUAV/camera.py
@@ -1,7 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''camera control for ptgrey chameleon camera'''
 
-import time, threading, sys, os, numpy, Queue, cv, errno, cPickle, signal, struct, fcntl, select, cStringIO
+import time, threading, sys, os, numpy, queue, cv, errno, pickle, signal, struct, fcntl, select, io
 
 # use the camera code from the cuav repo (see githib.com/tridge)
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', '..', 'cuav', 'camera'))
@@ -40,9 +40,9 @@ class camera_state(object):
         self.fps = 0
         self.scan_fps = 0
         self.cam = None
-        self.save_queue = Queue.Queue()
-        self.scan_queue = Queue.Queue()
-        self.transmit_queue = Queue.Queue()
+        self.save_queue = queue.Queue()
+        self.scan_queue = queue.Queue()
+        self.transmit_queue = queue.Queue()
         self.viewing = False
         self.depth = 8
         self.gcs_address = None
@@ -104,17 +104,17 @@ def cmd_camera(args):
         state.running = False
         print("stopped camera capture")
     elif args[0] == "status":
-        print("Cap %u imgs  %u err %u scan  %u regions %.0f jsize %.0f xmitq %u lst %u sq %.1f eff" % (
+        print(("Cap %u imgs  %u err %u scan  %u regions %.0f jsize %.0f xmitq %u lst %u sq %.1f eff" % (
             state.capture_count, state.error_count, state.scan_count, state.region_count, 
-            state.jpeg_size, state.xmit_queue, state.frame_loss, state.scan_queue.qsize(), state.efficiency))
+            state.jpeg_size, state.xmit_queue, state.frame_loss, state.scan_queue.qsize(), state.efficiency)))
     elif args[0] == "queue":
-        print("scan %u  save %u  transmit %u  eff %.1f  bw %.1f  rtt %.1f" % (
+        print(("scan %u  save %u  transmit %u  eff %.1f  bw %.1f  rtt %.1f" % (
                 state.scan_queue.qsize(),
                 state.save_queue.qsize(),
                 state.transmit_queue.qsize(),
                 state.efficiency,
                 state.bandwidth_used,
-                state.rtt_estimate))
+                state.rtt_estimate)))
     elif args[0] == "view":
         if mpstate.map is None:
             print("Please load map module first")
@@ -135,47 +135,47 @@ def cmd_camera(args):
         state.gcs_address = args[1]
     elif args[0] == "brightness":
         if len(args) != 2:
-            print("brightness=%f" % state.brightness)
+            print(("brightness=%f" % state.brightness))
         else:
             state.brightness = float(args[1])
     elif args[0] == "capbrightness":
         if len(args) != 2:
-            print("capbrightness=%u" % state.capture_brightness)
+            print(("capbrightness=%u" % state.capture_brightness))
         else:
             state.capture_brightness = int(args[1])
     elif args[0] == "gamma":
         if len(args) != 2:
-            print("gamma=%u" % state.gamma)
+            print(("gamma=%u" % state.gamma))
         else:
             state.gamma = int(args[1])
     elif args[0] == "quality":
         if len(args) != 2:
-            print("quality=%u" % state.quality)
+            print(("quality=%u" % state.quality))
         else:
             state.quality = int(args[1])
     elif args[0] == "bandwidth":
         if len(args) != 2:
-            print("bandwidth=%u" % state.bandwidth)
+            print(("bandwidth=%u" % state.bandwidth))
         else:
             state.bandwidth = int(args[1])
     elif args[0] == "loss":
         if len(args) != 2:
-            print("packet_loss=%u" % state.packet_loss)
+            print(("packet_loss=%u" % state.packet_loss))
         else:
             state.packet_loss = int(args[1])
     elif args[0] == "save":
         if len(args) != 2:
-            print("save_pgm=%s" % str(state.save_pgm))
+            print(("save_pgm=%s" % str(state.save_pgm)))
         else:
             state.save_pgm = bool(int(args[1]))
     elif args[0] == "transmit":
         if len(args) != 2:
-            print("transmit=%s" % str(state.transmit))
+            print(("transmit=%s" % str(state.transmit)))
         else:
             state.transmit = bool(int(args[1]))
     elif args[0] == "boundary":
         if len(args) != 2:
-            print("boundary=%s" % state.boundary)
+            print(("boundary=%s" % state.boundary))
         else:
             state.boundary = args[1]
     else:
@@ -209,7 +209,7 @@ def get_base_time():
         print('re-opening camera')
         chameleon.close(h)
         h = chameleon.open(state.colour, state.depth, state.capture_brightness)
-  print('base_time=%f' % base_time)
+  print(('base_time=%f' % base_time))
   return h, base_time, frame_time
 
 def capture_thread():
@@ -264,7 +264,7 @@ def capture_thread():
 
             last_frame_time = frame_time
             last_frame_counter = frame_counter
-        except chameleon.error, msg:
+        except chameleon.error as msg:
             state.error_count += 1
             state.error_msg = msg
     if h is not None:
@@ -293,7 +293,7 @@ def scan_thread():
             if state.scan_queue.qsize() > 100:
                 (frame_time,im) = state.scan_queue.get(timeout=0.2)
             (frame_time,im) = state.scan_queue.get(timeout=0.2)
-        except Queue.Empty:
+        except queue.Empty:
             continue
 
         t1 = time.time()
@@ -376,7 +376,7 @@ def transmit_thread():
 
             # send matches with a higher priority
             if state.transmit:
-                bsend.send(cPickle.dumps(pkt, cPickle.HIGHEST_PROTOCOL),
+                bsend.send(pickle.dumps(pkt, pickle.HIGHEST_PROTOCOL),
                            dest=(state.gcs_address, state.gcs_view_port),
                            priority=1)
 
@@ -399,7 +399,7 @@ def transmit_thread():
         bsend.set_packet_loss(state.packet_loss)
         bsend.set_bandwidth(state.bandwidth)
         pkt = ImagePacket(frame_time, jpeg)
-        bsend.send(cPickle.dumps(pkt, cPickle.HIGHEST_PROTOCOL),
+        bsend.send(pickle.dumps(pkt, pickle.HIGHEST_PROTOCOL),
                    dest=(state.gcs_address, state.gcs_view_port))
 
 
@@ -450,7 +450,7 @@ def view_thread():
             if buf is None:
                 continue
             try:
-                obj = cPickle.loads(str(buf))
+                obj = pickle.loads(str(buf))
                 if obj == None:
                     continue
             except Exception as e:
@@ -498,8 +498,8 @@ def view_thread():
                 # work out where we were at the time
                 try:
                     pos = state.mpos.position(obj.frame_time, 0)
-                except mav_position.MavInterpolatorException, msg:
-                    print msg
+                except mav_position.MavInterpolatorException as msg:
+                    print(msg)
                     pos = None
                 if pos:
                     mosaic.add_image(filename, img, pos)

--- a/modules/antenna.py
+++ b/modules/antenna.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''
 antenna pointing module
 Andrew Tridgell
@@ -31,7 +31,7 @@ def cmd_antenna(args):
         if state.gcs_location is None:
             print("GCS location not set")
         else:
-            print("GCS location %s" % str(self.gcs_location))
+            print(("GCS location %s" % str(self.gcs_location)))
         return
     state.gcs_location = (float(args[0]), float(args[1]))
         

--- a/modules/drop.py
+++ b/modules/drop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ''' simple bottle drop module'''
 
 import time
@@ -53,4 +53,4 @@ def mavlink_packet(m):
         check_drop(m)
     if m.get_type() == 'PARAM_VALUE':
         if str(m.param_id) == 'RC5_FUNCTION' and m.param_value != 1.0:
-            print("DROP WARNING: RC5_FUNCTION=%u" % m.param_value)
+            print(("DROP WARNING: RC5_FUNCTION=%u" % m.param_value))

--- a/modules/graph.py
+++ b/modules/graph.py
@@ -31,12 +31,12 @@ def cmd_graph(args):
     if len(args) == 0:
         # list current graphs
         for i in range(len(state.graphs)):
-            print("Graph %u: %s" % (i, state.graphs[i].fields))
+            print(("Graph %u: %s" % (i, state.graphs[i].fields)))
         return
 
     if args[0] == "timespan":
         if len(args) == 1:
-            print("timespan: %.1f" % state.timespan)
+            print(("timespan: %.1f" % state.timespan))
             return
         state.timespan = float(args[1])
         return
@@ -88,7 +88,7 @@ class Graph():
             caps = set(re.findall(re_caps, f))
             self.msg_types = self.msg_types.union(caps)
             self.field_types.append(caps)
-        print("Adding graph: %s" % self.fields)
+        print(("Adding graph: %s" % self.fields))
 
         self.values = [None]*len(self.fields)
         self.livegraph = live_graph.LiveGraph(self.fields,

--- a/modules/joystick.py
+++ b/modules/joystick.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''joystick interface module
 
 Contributed by AndrewF:
@@ -16,9 +16,9 @@ def get_joystick():
     try:
 	    j = pygame.joystick.Joystick(0) # create a joystick instance
 	    j.init() # init instance
-	    print 'joystick initialized: ' + j.get_name()
+	    print('joystick initialized: ' + j.get_name())
     except pygame.error:
-        print 'joystick not found.'
+        print('joystick not found.')
         return
 
     while not mpstate.status.exit:        

--- a/modules/kml.py
+++ b/modules/kml.py
@@ -1,14 +1,14 @@
-import BaseHTTPServer
+import http.server
 import os.path
 import threading
-import urlparse
+import urllib.parse
 
 import simplekml
 
 
-class Server(BaseHTTPServer.HTTPServer):
+class Server(http.server.HTTPServer):
   def __init__(self, handler, address='', port=9999, module_state=None):
-    BaseHTTPServer.HTTPServer.__init__(self, (address, port), handler)
+    http.server.HTTPServer.__init__(self, (address, port), handler)
     self.allow_reuse_address = True
     self.module_state = module_state
 
@@ -25,7 +25,7 @@ def content_type_for_file(path):
     return 'text/plain; charset=utf-8'
 
 
-class Handler(BaseHTTPServer.BaseHTTPRequestHandler):
+class Handler(http.server.BaseHTTPRequestHandler):
   def log_request(code, size=None):
     pass
 

--- a/modules/lib/GAreader.py
+++ b/modules/lib/GAreader.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''
 Module to read DTM files published by Geoscience Australia
 Written by Stephen Dade (stephen_dade@hotmail.com
@@ -87,13 +87,13 @@ class ERMap:
 
     def printBoundingBox(self):
         '''Print the bounding box that this DEM covers'''
-        print "Bounding Latitude: "
-        print self.startlatitude
-        print self.endlatitude
+        print("Bounding Latitude: ")
+        print(self.startlatitude)
+        print(self.endlatitude)
 
-        print "Bounding Longitude: "
-        print self.startlongitude
-        print self.endlongitude
+        print("Bounding Longitude: ")
+        print(self.startlongitude)
+        print(self.endlongitude)
 
     def getPercentBlank(self):
         '''Print how many null cells are in the DEM - Quality measure'''
@@ -105,7 +105,7 @@ class ERMap:
             else:
                 nonblank = nonblank + 1
 
-        print "Blank tiles =  ", blank, "out of ", (nonblank+blank)
+        print("Blank tiles =  ", blank, "out of ", (nonblank+blank))
 
     def getAltitudeAtPoint(self, latty, longy):
         '''Return the altitude at a particular long/lat'''
@@ -166,7 +166,7 @@ class ERMap:
 
 if __name__ == '__main__':
 
-    print "./Canberra/GSNSW_P756demg"
+    print("./Canberra/GSNSW_P756demg")
     mappy = ERMap()
     mappy.read_ermapper(os.path.join(os.environ['HOME'], './Documents/Elevation/Canberra/GSNSW_P756demg'))
 
@@ -178,21 +178,21 @@ if __name__ == '__main__':
 
     #test the altitude (around Canberra):
     alt = mappy.getAltitudeAtPoint(-35.274411, 149.097504)
-    print "Alt at (-35.274411, 149.097504) is 807m (Google) or " + str(alt)
+    print("Alt at (-35.274411, 149.097504) is 807m (Google) or " + str(alt))
     alt = mappy.getAltitudeAtPoint(-35.239648, 149.126118)
-    print "Alt at (-35.239648, 149.126118) is 577m (Google) or " + str(alt)
+    print("Alt at (-35.239648, 149.126118) is 577m (Google) or " + str(alt))
     alt = mappy.getAltitudeAtPoint(-35.362751, 149.165361)
-    print "Alt at (-35.362751, 149.165361) is 584m (Google) or " + str(alt)
+    print("Alt at (-35.362751, 149.165361) is 584m (Google) or " + str(alt))
     alt = mappy.getAltitudeAtPoint(-35.306992, 149.194274)
-    print "Alt at (-35.306992, 149.194274) is 570m (Google) or " + str(alt)
+    print("Alt at (-35.306992, 149.194274) is 570m (Google) or " + str(alt))
     alt = mappy.getAltitudeAtPoint(-35.261612, 149.542091)
-    print "Alt at (-35.261612, 149.542091) is 766m (Google) or " + str(alt)
+    print("Alt at (-35.261612, 149.542091) is 766m (Google) or " + str(alt))
     alt = mappy.getAltitudeAtPoint(-35.052544, 149.509165)
-    print "Alt at (-35.052544, 149.509165) is 700m (Google) or " + str(alt)
+    print("Alt at (-35.052544, 149.509165) is 700m (Google) or " + str(alt))
     alt = mappy.getAltitudeAtPoint(-35.045126, 149.257482)
-    print "Alt at (-35.045126, 149.257482) is 577m (Google) or " + str(alt)
+    print("Alt at (-35.045126, 149.257482) is 577m (Google) or " + str(alt))
     alt = mappy.getAltitudeAtPoint(-35.564044, 149.177657)
-    print "Alt at (-35.564044, 149.177657) is 1113m (Google) or " + str(alt)
+    print("Alt at (-35.564044, 149.177657) is 1113m (Google) or " + str(alt))
 
 
 

--- a/modules/lib/libchecklist.py
+++ b/modules/lib/libchecklist.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
   MAVProxy checklist, implemented in a child process
@@ -29,7 +29,7 @@ class UI():
 
     def child_task(self):
         '''child process - this holds all the GUI elements'''
-        import Tkinter as tk
+        import tkinter as tk
 
         '''curStep is which step in the list we're up to, increments +1 for each list completed
         it is the same as the column number of the checklist item'''
@@ -110,7 +110,7 @@ class UI():
 
     def createWidgets(self, frame):
         '''Create the controls on the UI'''
-        import Tkinter as tk
+        import tkinter as tk
 
         '''Group Labels'''
         AssemblyLabel = tk.Label(frame, text="During Assembly")
@@ -243,14 +243,14 @@ class UI():
 
     def beforeAssemblyListCheck(self):
         '''Event for the "Checklist Complete" button for the Before Assembly section'''
-        import Tkinter as tk
-        import tkMessageBox
+        import tkinter as tk
+        import tkinter.messagebox
 
         '''Check all of the checklist for ticks'''
-        for key, value in self.beforeAssemblyList.items():
+        for key, value in list(self.beforeAssemblyList.items()):
             state = value.get()
             if state == 0 or state == 2:
-                tkMessageBox.showinfo("Error", "Item not ticked: " + key)
+                tkinter.messagebox.showinfo("Error", "Item not ticked: " + key)
                 return
 
         '''disable all checkboxes in this column'''
@@ -265,14 +265,14 @@ class UI():
 
     def beforeEngineCheck(self):
         '''Event for the "Checklist Complete" button for the Before Engine Start section'''
-        import Tkinter as tk
-        import tkMessageBox
+        import tkinter as tk
+        import tkinter.messagebox
 
         '''Check all of the checklist for ticks'''
-        for key, value in self.beforeEngineList.items():
+        for key, value in list(self.beforeEngineList.items()):
             state = value.get()
             if state == 0 or state == 2:
-                tkMessageBox.showinfo("Error", "Item not ticked: " + key)
+                tkinter.messagebox.showinfo("Error", "Item not ticked: " + key)
                 return
 
         '''disable all checkboxes in this column'''
@@ -287,14 +287,14 @@ class UI():
 
     def beforeTakeoffCheck(self):
         '''Event for the "Checklist Complete" button for the Before Takeoff section'''
-        import Tkinter as tk
-        import tkMessageBox
+        import tkinter as tk
+        import tkinter.messagebox
 
         '''Check all of the checklist for ticks'''
-        for key, value in self.beforeTakeoffList.items():
+        for key, value in list(self.beforeTakeoffList.items()):
             state = value.get()
             if state == 0 or state == 2:
-                tkMessageBox.showinfo("Error", "Item not ticked: " + key)
+                tkinter.messagebox.showinfo("Error", "Item not ticked: " + key)
                 return
 
         '''disable all checkboxes in this column'''
@@ -310,14 +310,14 @@ class UI():
 
     def beforeCruiseCheck(self):
         '''Event for the "Checklist Complete" button for the Before Cruise/AUTO section'''
-        import Tkinter as tk
-        import tkMessageBox
+        import tkinter as tk
+        import tkinter.messagebox
 
         '''Check all of the checklist for ticks'''
-        for key, value in self.beforeCruiseList.items():
+        for key, value in list(self.beforeCruiseList.items()):
             state = value.get()
             if state == 0 or state == 2:
-                tkMessageBox.showinfo("Error", "Item not ticked: " + key)
+                tkinter.messagebox.showinfo("Error", "Item not ticked: " + key)
                 return
 
         '''disable all checkboxes in this column'''
@@ -327,20 +327,20 @@ class UI():
 
         '''if we made it here, the checklist is OK'''
         '''self.bottleDropButton.config(state="normal")'''
-        tkMessageBox.showinfo("Information", "Checklist Completed!")
+        tkinter.messagebox.showinfo("Information", "Checklist Completed!")
         self.beforeCruiseButton.config(text='Checklist Completed', state="disabled")
         self.curStep = 4
 
     def bottleDropCheck(self):
         '''Event for the "Checklist Complete" button for the Before Bottle Drop section'''
-        import Tkinter as tk
-        import tkMessageBox
+        import tkinter as tk
+        import tkinter.messagebox
 
         '''Check all of the checklist for ticks'''
-        for key, value in self.bottleDropList.items():
+        for key, value in list(self.bottleDropList.items()):
             state = value.get()
             if state == 0 or state == 2:
-                tkMessageBox.showinfo("Error", "Item not ticked: " + key)
+                tkinter.messagebox.showinfo("Error", "Item not ticked: " + key)
                 return
 
         '''disable all checkboxes in this column'''
@@ -355,14 +355,14 @@ class UI():
 
     def beforeLandingCheck(self):
         '''Event for the "Checklist Complete" button for the Before Landing section'''
-        import Tkinter as tk
-        import tkMessageBox
+        import tkinter as tk
+        import tkinter.messagebox
 
         '''Check all of the checklist for ticks'''
-        for key, value in self.beforeLandingList.items():
+        for key, value in list(self.beforeLandingList.items()):
             state = value.get()
             if state == 0 or state == 2:
-                tkMessageBox.showinfo("Error", "Item not ticked: " + key)
+                tkinter.messagebox.showinfo("Error", "Item not ticked: " + key)
                 return
 
         '''disable all checkboxes in this column'''
@@ -377,14 +377,14 @@ class UI():
 
     def beforeShutdownCheck(self):
         '''Event for the "Checklist Complete" button for the Before Landing section'''
-        import Tkinter as tk
-        import tkMessageBox
+        import tkinter as tk
+        import tkinter.messagebox
 
         '''Check all of the checklist for ticks'''
-        for key, value in self.beforeShutdownList.items():
+        for key, value in list(self.beforeShutdownList.items()):
             state = value.get()
             if state == 0 or state == 2:
-                tkMessageBox.showinfo("Error", "Item not ticked: " + key)
+                tkinter.messagebox.showinfo("Error", "Item not ticked: " + key)
                 return
 
         '''disable all checkboxes in this column'''
@@ -394,7 +394,7 @@ class UI():
 
         '''if we made it here, the checklist is OK'''
         self.beforeShutdownButton.config(text='Checklist Completed', state="disabled")
-        tkMessageBox.showinfo("Information", "Checklist Completed!")
+        tkinter.messagebox.showinfo("Information", "Checklist Completed!")
         self.curStep = 7
 
     def close(self):
@@ -410,7 +410,7 @@ class UI():
     def on_timer(self):
         '''this timer periodically checks the inter-process pipe
         for any updated checklist items'''
-        import Tkinter as tk
+        import tkinter as tk
         if self.close_event.wait(0.001):
             self.timer.Stop()
             self.Destroy()

--- a/modules/lib/live_graph.py
+++ b/modules/lib/live_graph.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 

--- a/modules/lib/mp_elevation.py
+++ b/modules/lib/mp_elevation.py
@@ -62,21 +62,21 @@ if __name__ == "__main__":
     t0 = time.time()
     alt = EleModel.GetElevation(lat, lon)
     t1 = time.time()
-    print("Altitude at (%.6f, %.6f) is %u m. Pulled at %.1f FPS" % (lat, lon, alt, 1/(t1-t0)))
+    print(("Altitude at (%.6f, %.6f) is %u m. Pulled at %.1f FPS" % (lat, lon, alt, 1/(t1-t0))))
 
     lat = opts.lat+0.001
     lon = opts.lon+0.001
     t0 = time.time()
     alt = EleModel.GetElevation(lat, lon)
     t1 = time.time()
-    print("Altitude at (%.6f, %.6f) is %u m. Pulled at %.1f FPS" % (lat, lon, alt, 1/(t1-t0)))
+    print(("Altitude at (%.6f, %.6f) is %u m. Pulled at %.1f FPS" % (lat, lon, alt, 1/(t1-t0))))
 
     lat = opts.lat-0.001
     lon = opts.lon-0.001
     t0 = time.time()
     alt = EleModel.GetElevation(lat, lon)
     t1 = time.time()
-    print("Altitude at (%.6f, %.6f) is %u m. Pulled at %.1f FPS" % (lat, lon, alt, 1/(t1-t0)))
+    print(("Altitude at (%.6f, %.6f) is %u m. Pulled at %.1f FPS" % (lat, lon, alt, 1/(t1-t0))))
 
 
 

--- a/modules/lib/mp_image.py
+++ b/modules/lib/mp_image.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''
 display a image with scrollbars in a subprocess
 Andrew Tridgell
@@ -154,9 +154,9 @@ if __name__ == "__main__":
 
     while im.is_alive():
         for event in im.events():
-            print event.ClassName
+            print(event.ClassName)
             if event.ClassName == 'wxMouseEvent':
-                print 'mouse', event.X, event.Y
+                print('mouse', event.X, event.Y)
             if event.ClassName == 'wxKeyEvent':
-                print 'key %u' % event.KeyCode
+                print('key %u' % event.KeyCode)
         time.sleep(0.1)

--- a/modules/lib/mp_slipmap.py
+++ b/modules/lib/mp_slipmap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''
 slipmap based on mp_tile
 Andrew Tridgell
@@ -468,7 +468,7 @@ class MPSlipMapFrame(wx.Frame):
         state = self.state
 
         if layers is None:
-            layers = state.layers.keys()
+            layers = list(state.layers.keys())
         for layer in layers:
             if key in state.layers[layer]:
                 return state.layers[layer][key]
@@ -681,7 +681,7 @@ class MPSlipMapPanel(wx.Panel):
 
     def draw_objects(self, objects, bounds, img):
         '''draw objects on the image'''
-        keys = objects.keys()
+        keys = list(objects.keys())
         keys.sort()
         for k in keys:
             obj = objects[k]
@@ -708,7 +708,7 @@ class MPSlipMapPanel(wx.Panel):
 
         # draw layer objects
         img = cv.CloneImage(self.map_img)
-        keys = state.layers.keys()
+        keys = list(state.layers.keys())
         keys.sort()
         for k in keys:
             self.draw_objects(state.layers[k], bounds, img)
@@ -807,7 +807,7 @@ class MPSlipMapPanel(wx.Panel):
     def clear_thumbnails(self):
         state = self.state
         for l in state.layers:
-            keys = state.layers[l].keys()[:]
+            keys = list(state.layers[l].keys())[:]
             for key in keys:
                 if (isinstance(state.layers[l][key], SlipThumbnail)
                     and not isinstance(state.layers[l][key], SlipIcon)):
@@ -885,9 +885,9 @@ if __name__ == "__main__":
         while sm.event_count() > 0:
             obj = sm.get_event()
             if isinstance(obj, SlipMouseEvent):
-                print("Mouse event at %s (X/Y=%u/%u) for %u objects" % (obj.latlon,
+                print(("Mouse event at %s (X/Y=%u/%u) for %u objects" % (obj.latlon,
                                                                         obj.event.X, obj.event.Y,
-                                                                        len(obj.selected)))
+                                                                        len(obj.selected))))
             if isinstance(obj, SlipKeyEvent):
-                print("Key event at %s for %u objects" % (obj.latlon, len(obj.selected)))
+                print(("Key event at %s for %u objects" % (obj.latlon, len(obj.selected))))
         time.sleep(0.1)

--- a/modules/lib/mp_tile.py
+++ b/modules/lib/mp_tile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''
 access satellite map tile database
 
@@ -199,7 +199,7 @@ class MPTile:
 		while self.tiles_pending() > 0:
 			time.sleep(self.tile_delay)
 
-			keys = self._download_pending.keys()[:]
+			keys = list(self._download_pending.keys())[:]
 
 			# work out which one to download next, choosing by request_time
 			tile_info = self._download_pending[keys[0]]
@@ -213,20 +213,20 @@ class MPTile:
 			
 			try:
 				if self.debug:
-					print("Downloading %s [%u left]" % (url, len(keys)))
+					print(("Downloading %s [%u left]" % (url, len(keys))))
 				resp,img = http.request(url)
 			except httplib2.HttpLib2Error as e:
 				#print('Error loading %s' % url)
 				self._tile_cache[key] = self._unavailable
 				self._download_pending.pop(key)
 				if self.debug:
-					print("Failed %s: %s" % (url, str(e)))
+					print(("Failed %s: %s" % (url, str(e))))
 				continue
 			if 'content-type' not in resp or resp['content-type'].find('image') == -1:
 				self._tile_cache[key] = self._unavailable
 				self._download_pending.pop(key)
 				if self.debug:
-					print("non-image response %s" % url)
+					print(("non-image response %s" % url))
 				continue
 				
 
@@ -234,7 +234,7 @@ class MPTile:
 			md5 = hashlib.md5(img).hexdigest()
 			if md5 in BLANK_TILES:
 				if self.debug:
-					print("blank tile %s" % url)
+					print(("blank tile %s" % url))
 				self._tile_cache[key] = self._unavailable
 				self._download_pending.pop(key)
 				continue
@@ -410,7 +410,7 @@ class MPTile:
 
 		# choose a zoom level if not provided
 		if zoom is None:
-			zooms = range(self.min_zoom, self.max_zoom+1)
+			zooms = list(range(self.min_zoom, self.max_zoom+1))
 		else:
 			zooms = [zoom]
 		for zoom in zooms:
@@ -507,21 +507,21 @@ if __name__ == "__main__":
 		lon = bounds[1]
 		ground_width = max(mp_util.gps_distance(lat, lon, lat, lon+bounds[3]),
 				   mp_util.gps_distance(lat, lon, lat-bounds[2], lon))
-		print lat, lon, ground_width
+		print(lat, lon, ground_width)
 
 	mt = MPTile(debug=opts.debug, service=opts.service,
 		    tile_delay=opts.delay, max_zoom=opts.max_zoom)
 	if opts.zoom is None:
-		zooms = range(mt.min_zoom, mt.max_zoom+1)
+		zooms = list(range(mt.min_zoom, mt.max_zoom+1))
 	else:
 		zooms = [opts.zoom]
 	for zoom in zooms:
 		tlist = mt.area_to_tile_list(lat, lon, width=1024, height=1024,
 					     ground_width=ground_width, zoom=zoom)
-		print("zoom %u needs %u tiles" % (zoom, len(tlist)))
+		print(("zoom %u needs %u tiles" % (zoom, len(tlist))))
 		for tile in tlist:
 			mt.load_tile(tile)
 		while mt.tiles_pending() > 0:
 			time.sleep(2)
-			print("Waiting on %u tiles" % mt.tiles_pending())
+			print(("Waiting on %u tiles" % mt.tiles_pending()))
 	print('Done')

--- a/modules/lib/mp_util.py
+++ b/modules/lib/mp_util.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''common mavproxy utility functions'''
 
 import math, os
@@ -6,38 +6,38 @@ import math, os
 radius_of_earth = 6378100.0 # in meters
 
 def gps_distance(lat1, lon1, lat2, lon2):
-	'''return distance between two points in meters,
-	coordinates are in degrees
-	thanks to http://www.movable-type.co.uk/scripts/latlong.html'''
-	from math import radians, cos, sin, sqrt, atan2
-	lat1 = radians(lat1)
-	lat2 = radians(lat2)
-	lon1 = radians(lon1)
-	lon2 = radians(lon2)
-	dLat = lat2 - lat1
-	dLon = lon2 - lon1
+    '''return distance between two points in meters,
+    coordinates are in degrees
+    thanks to http://www.movable-type.co.uk/scripts/latlong.html'''
+    from math import radians, cos, sin, sqrt, atan2
+    lat1 = radians(lat1)
+    lat2 = radians(lat2)
+    lon1 = radians(lon1)
+    lon2 = radians(lon2)
+    dLat = lat2 - lat1
+    dLon = lon2 - lon1
 
-	a = sin(0.5*dLat)**2 + sin(0.5*dLon)**2 * cos(lat1) * cos(lat2)
-	c = 2.0 * atan2(sqrt(a), sqrt(1.0-a))
-	return radius_of_earth * c
+    a = sin(0.5*dLat)**2 + sin(0.5*dLon)**2 * cos(lat1) * cos(lat2)
+    c = 2.0 * atan2(sqrt(a), sqrt(1.0-a))
+    return radius_of_earth * c
 
 
 def gps_bearing(lat1, lon1, lat2, lon2):
-	'''return bearing between two points in degrees, in range 0-360
-	thanks to http://www.movable-type.co.uk/scripts/latlong.html'''
-	from math import sin, cos, atan2, radians, degrees
-	lat1 = radians(lat1)
-	lat2 = radians(lat2)
-	lon1 = radians(lon1)
-	lon2 = radians(lon2)
-	dLat = lat2 - lat1
-	dLon = lon2 - lon1    
-	y = sin(dLon) * cos(lat2)
-	x = cos(lat1)*sin(lat2) - sin(lat1)*cos(lat2)*cos(dLon)
-	bearing = degrees(atan2(y, x))
-	if bearing < 0:
-		bearing += 360.0
-	return bearing
+    '''return bearing between two points in degrees, in range 0-360
+    thanks to http://www.movable-type.co.uk/scripts/latlong.html'''
+    from math import sin, cos, atan2, radians, degrees
+    lat1 = radians(lat1)
+    lat2 = radians(lat2)
+    lon1 = radians(lon1)
+    lon2 = radians(lon2)
+    dLat = lat2 - lat1
+    dLon = lon2 - lon1    
+    y = sin(dLon) * cos(lat2)
+    x = cos(lat1)*sin(lat2) - sin(lat1)*cos(lat2)*cos(dLon)
+    bearing = degrees(atan2(y, x))
+    if bearing < 0:
+        bearing += 360.0
+    return bearing
 
 
 def wrap_valid_longitude(lon):
@@ -47,101 +47,101 @@ def wrap_valid_longitude(lon):
   return (((lon + 180.0) % 360.0) - 180.0)
 
 def gps_newpos(lat, lon, bearing, distance):
-	'''extrapolate latitude/longitude given a heading and distance 
-	thanks to http://www.movable-type.co.uk/scripts/latlong.html
-	'''
-	from math import sin, asin, cos, atan2, radians, degrees
+    '''extrapolate latitude/longitude given a heading and distance 
+    thanks to http://www.movable-type.co.uk/scripts/latlong.html
+    '''
+    from math import sin, asin, cos, atan2, radians, degrees
 
-	lat1 = radians(lat)
-	lon1 = radians(lon)
-	brng = radians(bearing)
-	dr = distance/radius_of_earth
+    lat1 = radians(lat)
+    lon1 = radians(lon)
+    brng = radians(bearing)
+    dr = distance/radius_of_earth
 
-	lat2 = asin(sin(lat1)*cos(dr) +
-		    cos(lat1)*sin(dr)*cos(brng))
-	lon2 = lon1 + atan2(sin(brng)*sin(dr)*cos(lat1), 
-			    cos(dr)-sin(lat1)*sin(lat2))
-	return (degrees(lat2), wrap_valid_longitude(degrees(lon2)))
+    lat2 = asin(sin(lat1)*cos(dr) +
+            cos(lat1)*sin(dr)*cos(brng))
+    lon2 = lon1 + atan2(sin(brng)*sin(dr)*cos(lat1), 
+                cos(dr)-sin(lat1)*sin(lat2))
+    return (degrees(lat2), wrap_valid_longitude(degrees(lon2)))
 
 def gps_offset(lat, lon, east, north):
-	'''return new lat/lon after moving east/north
-	by the given number of meters'''
-	bearing = math.degrees(math.atan2(east, north))
-	distance = math.sqrt(east**2 + north**2)
-	return gps_newpos(lat, lon, bearing, distance)
+    '''return new lat/lon after moving east/north
+    by the given number of meters'''
+    bearing = math.degrees(math.atan2(east, north))
+    distance = math.sqrt(east**2 + north**2)
+    return gps_newpos(lat, lon, bearing, distance)
 
 
 def mkdir_p(dir):
-	'''like mkdir -p'''
-	if not dir:
-		return
-	if dir.endswith("/"):
-		mkdir_p(dir[:-1])
-		return
-	if os.path.isdir(dir):
-		return
-	mkdir_p(os.path.dirname(dir))
-	try:
-		os.mkdir(dir)
-	except Exception:
-		pass
+    '''like mkdir -p'''
+    if not dir:
+        return
+    if dir.endswith("/"):
+        mkdir_p(dir[:-1])
+        return
+    if os.path.isdir(dir):
+        return
+    mkdir_p(os.path.dirname(dir))
+    try:
+        os.mkdir(dir)
+    except Exception:
+        pass
 
 def polygon_load(filename):
-	'''load a polygon from a file'''
-	ret = []
-        f = open(filename)
-        for line in f:
-		if line.startswith('#'):
-			continue
-		line = line.strip()
-		if not line:
-			continue
-		a = line.split()
-		if len(a) != 2:
-			raise RuntimeError("invalid polygon line: %s" % line)
-		ret.append((float(a[0]), float(a[1])))
-        f.close()
-	return ret
+    '''load a polygon from a file'''
+    ret = []
+    f = open(filename)
+    for line in f:
+        if line.startswith('#'):
+            continue
+        line = line.strip()
+        if not line:
+            continue
+        a = line.split()
+        if len(a) != 2:
+            raise RuntimeError("invalid polygon line: %s" % line)
+        ret.append((float(a[0]), float(a[1])))
+    f.close()
+    return ret
 
 
 def polygon_bounds(points):
-	'''return bounding box of a polygon in (x,y,width,height) form'''
-        (minx, miny) = points[0]
-        (maxx, maxy) = points[0]
-        for p in points:
-            minx = min(minx, p[0])
-            maxx = max(maxx, p[0])
-            miny = min(miny, p[1])
-            maxy = max(maxy, p[1])
-	return (minx, miny, maxx-minx, maxy-miny)
+    '''return bounding box of a polygon in (x,y,width,height) form'''
+    (minx, miny) = points[0]
+    (maxx, maxy) = points[0]
+    for p in points:
+        minx = min(minx, p[0])
+        maxx = max(maxx, p[0])
+        miny = min(miny, p[1])
+        maxy = max(maxy, p[1])
+    return (minx, miny, maxx-minx, maxy-miny)
 
 def bounds_overlap(bound1, bound2):
-	'''return true if two bounding boxes overlap'''
-	(x1,y1,w1,h1) = bound1
-	(x2,y2,w2,h2) = bound2
-	if x1+w1 < x2:
-		return False
-	if x2+w2 < x1:
-		return False
-	if y1+h1 < y2:
-		return False
-	if y2+h2 < y1:
-		return False
-	return True
+    '''return true if two bounding boxes overlap'''
+    (x1,y1,w1,h1) = bound1
+    (x2,y2,w2,h2) = bound2
+    if x1+w1 < x2:
+        return False
+    if x2+w2 < x1:
+        return False
+    if y1+h1 < y2:
+        return False
+    if y2+h2 < y1:
+        return False
+    return True
 
 
 class object_container:
-	'''return a picklable object from an existing object,
-	containing all of the normal attributes of the original'''
-	def __init__(self, object):
-		for v in dir(object):
-			if not v.startswith('__') and v not in ['this']:
-				try:
-					a = getattr(object, v)
-					if (hasattr(a, '__call__') or
-					    hasattr(a, '__swig_destroy__') or
-					    str(a).find('Swig Object') != -1):
-						continue
-					setattr(self, v, a)
-				except Exception:
-					pass
+    '''return a picklable object from an existing object,
+    containing all of the normal attributes of the original'''
+    def __init__(self, object):
+        for v in dir(object):
+            if not v.startswith('__') and v not in ['this']:
+                try:
+                    a = getattr(object, v)
+                    if (hasattr(a, '__call__') or
+                        hasattr(a, '__swig_destroy__') or
+                        str(a).find('Swig Object') != -1):
+                        continue
+                    setattr(self, v, a)
+                except Exception:
+                    pass

--- a/modules/lib/mp_widgets.py
+++ b/modules/lib/mp_widgets.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''
 some useful wx widgets
 

--- a/modules/lib/textconsole.py
+++ b/modules/lib/textconsole.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
   MAVProxy default console

--- a/modules/lib/wxconsole.py
+++ b/modules/lib/wxconsole.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
   MAVProxy message console, implemented in a child process  

--- a/modules/map.py
+++ b/modules/map.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''
 map display module
 Andrew Tridgell

--- a/modules/mmap.py
+++ b/modules/mmap.py
@@ -23,7 +23,7 @@ class MetaMessage(object):
     return self.msg_type
 
   def to_dict(self):
-    d = dict(self.data.items())
+    d = dict(list(self.data.items()))
     d['mavpackettype'] = self.msg_type
     return d
 
@@ -51,7 +51,7 @@ class MessageMemo(object):
       return None
 
   def message_types(self):
-    return self._d.keys()
+    return list(self._d.keys())
 
   def has_message(self, mt):
     mtype = mt.upper()
@@ -77,7 +77,7 @@ class LinkStateThread(threading.Thread):
       self._running_flag = False
 
   def terminate(self):
-    print "terminating metalinkquality!"
+    print("terminating metalinkquality!")
     self.stop.set()
 
   def update_meta_linkquality(self):
@@ -107,7 +107,7 @@ class ModuleState(object):
     self.linkstatethread.start()
 
   def terminate(self):
-    print "mmap module state terminate"
+    print("mmap module state terminate")
     self.server.terminate()
     self.linkstatethread.terminate()
 
@@ -170,7 +170,7 @@ def init(module_context):
 
 def unload():
   """unload module"""
-  print "mmap module unload"
+  print("mmap module unload")
   global g_module_context
   g_module_context.mmap_state.terminate()
 

--- a/modules/ppp.py
+++ b/modules/ppp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''
 A PPP over MAVLink module
 Andrew Tridgell
@@ -34,7 +34,7 @@ def ppp_read(ppp_fd):
         # EOF on the child fd
         stop_ppp_link()
         return
-    print("ppp packet len=%u" % len(buf))
+    print(("ppp packet len=%u" % len(buf)))
     master = mpstate.master()
     master.mav.ppp_send(len(buf), buf)
 
@@ -81,11 +81,11 @@ def cmd_ppp(args):
     state = mpstate.ppp_state
     usage = "ppp <command|start|stop>"
     if len(args) == 0:
-        print usage
+        print(usage)
         return
     if args[0] == "command":
         if len(args) == 1:
-            print("ppp.command=%s" % " ".join(state.command))
+            print(("ppp.command=%s" % " ".join(state.command)))
         else:
             state.command = args[1:]
     elif args[0] == "start":
@@ -110,5 +110,5 @@ def mavlink_packet(m):
     '''handle an incoming mavlink packet'''
     state = mpstate.ppp_state
     if m.get_type() == 'PPP' and state.ppp_fd != -1:
-        print("got ppp mavlink pkt len=%u" % m.length)
+        print(("got ppp mavlink pkt len=%u" % m.length))
         os.write(state.ppp_fd, m.data[:m.length])

--- a/modules/sensors.py
+++ b/modules/sensors.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''monitor sensor consistancy'''
 
 import time, math, mavutil

--- a/modules/test.py
+++ b/modules/test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''test flight for DCM noise'''
 
 import time, math


### PR DESCRIPTION
## Summary
- convert mavproxy and modules to Python 3 syntax
- update shebangs
- modernize mmap_server to use cheroot and werkzeug middleware
- clean up indentation issues
- ensure auxiliary server starts under Python 3

## Testing
- `python3 -m py_compile mavproxy.py $(find modules -name '*.py')`
- `python3 - <<'PY'
from modules.lib import mmap_server
srv = mmap_server.start_server('127.0.0.1', 8000, None)
print('server started')
srv.stop()
print('server stopped')
PY`


------
https://chatgpt.com/codex/tasks/task_e_6868b77b9adc832493b761f6cb2e2fb2